### PR TITLE
Update barcode scanning listener for API change

### DIFF
--- a/src/app/pages/scan/scan.page.ts
+++ b/src/app/pages/scan/scan.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { MenuService } from '../../services/menu.service';
-import { BarcodeScanner, BarcodeFormat, BarcodesScannedEvent } from '@capacitor-mlkit/barcode-scanning';
+import { BarcodeScanner, BarcodeFormat, BarcodeScannedEvent } from '@capacitor-mlkit/barcode-scanning';
 import { ToastrService } from 'ngx-toastr';
 import { SpinnerService } from '../../services/spinner.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -44,8 +44,8 @@ export class ScanPage {
       // Start scanner
       BarcodeScanner.startScan({ formats: [BarcodeFormat.QrCode] });
 
-      BarcodeScanner.addListener('barcodesScanned', async (event: BarcodesScannedEvent) => {
-        const barcode = event.barcodes[0];
+      BarcodeScanner.addListener('barcodeScanned', async (event: BarcodeScannedEvent) => {
+        const barcode = event.barcode;
         if (barcode) {
           this.spinnerService.show();
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- use `BarcodeScannedEvent` type with updated `barcodeScanned` listener
- handle single `event.barcode` when processing scan results

## Testing
- ❌ `npm test -- --watch=false` (Cannot find name 'async' in multiple spec files)


------
https://chatgpt.com/codex/tasks/task_e_68beb54ea7248320b996b1d8b5c10841