### PR TITLE
refactor: use waitForAsync in page specs

### DIFF
--- a/src/app/pages/calendar-available/calendar-available.page.spec.ts
+++ b/src/app/pages/calendar-available/calendar-available.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CalendarAvailablePage } from './calendar-available.page';
 
 describe('CalendarAvailablePage', () => {
   let component: CalendarAvailablePage;
   let fixture: ComponentFixture<CalendarAvailablePage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(CalendarAvailablePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/calendar/calendar.page.spec.ts
+++ b/src/app/pages/calendar/calendar.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CalendarPage } from './calendar.page';
 
 describe('CalendarPage', () => {
   let component: CalendarPage;
   let fixture: ComponentFixture<CalendarPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(CalendarPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/chat/chat.page.spec.ts
+++ b/src/app/pages/chat/chat.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ChatPage } from './chat.page';
 
 describe('ChatPage', () => {
   let component: ChatPage;
   let fixture: ComponentFixture<ChatPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(ChatPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/client-detail/client-detail.page.spec.ts
+++ b/src/app/pages/client-detail/client-detail.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ClientDetailPage } from './client-detail.page';
 
 describe('ClientDetailPage', () => {
   let component: ClientDetailPage;
   let fixture: ComponentFixture<ClientDetailPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(ClientDetailPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/client-level/client-level.page.spec.ts
+++ b/src/app/pages/client-level/client-level.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ClientLevelPage } from './client-level.page';
 
 describe('ClientLevelPage', () => {
   let component: ClientLevelPage;
   let fixture: ComponentFixture<ClientLevelPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(ClientLevelPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/clients/clients.page.spec.ts
+++ b/src/app/pages/clients/clients.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ClientsPage } from './clients.page';
 
 describe('ClientsPage', () => {
   let component: ClientsPage;
   let fixture: ComponentFixture<ClientsPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(ClientsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/course-detail-level/course-detail-level.page.spec.ts
+++ b/src/app/pages/course-detail-level/course-detail-level.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CourseDetailLevelPage } from './course-detail-level.page';
 
 describe('CourseDetailLevelPage', () => {
   let component: CourseDetailLevelPage;
   let fixture: ComponentFixture<CourseDetailLevelPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(CourseDetailLevelPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/course-detail/course-detail.page.spec.ts
+++ b/src/app/pages/course-detail/course-detail.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CourseDetailPage } from './course-detail.page';
 
 describe('CourseDetailPage', () => {
   let component: CourseDetailPage;
   let fixture: ComponentFixture<CourseDetailPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(CourseDetailPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/course-group/course-group.page.spec.ts
+++ b/src/app/pages/course-group/course-group.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CourseGroupPage } from './course-group.page';
 
 describe('CourseGroupPage', () => {
   let component: CourseGroupPage;
   let fixture: ComponentFixture<CourseGroupPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(CourseGroupPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/course-participation/course-participation.page.spec.ts
+++ b/src/app/pages/course-participation/course-participation.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CourseParticipationPage } from './course-participation.page';
 
 describe('CourseParticipationPage', () => {
   let component: CourseParticipationPage;
   let fixture: ComponentFixture<CourseParticipationPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(CourseParticipationPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/course-transfer/course-transfer.page.spec.ts
+++ b/src/app/pages/course-transfer/course-transfer.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CourseTransferPage } from './course-transfer.page';
 
 describe('CourseTransferPage', () => {
   let component: CourseTransferPage;
   let fixture: ComponentFixture<CourseTransferPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(CourseTransferPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/home/home.page.spec.ts
+++ b/src/app/pages/home/home.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HomePage } from './home.page';
 
 describe('HomePage', () => {
   let component: HomePage;
   let fixture: ComponentFixture<HomePage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(HomePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/login/login.page.spec.ts
+++ b/src/app/pages/login/login.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LoginPage } from './login.page';
 
 describe('LoginPage', () => {
   let component: LoginPage;
   let fixture: ComponentFixture<LoginPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(LoginPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/messages/messages.page.spec.ts
+++ b/src/app/pages/messages/messages.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MessagesPage } from './messages.page';
 
 describe('MessagesPage', () => {
   let component: MessagesPage;
   let fixture: ComponentFixture<MessagesPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(MessagesPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/meteo/meteo.page.spec.ts
+++ b/src/app/pages/meteo/meteo.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MeteoPage } from './meteo.page';
 
 describe('MeteoPage', () => {
   let component: MeteoPage;
   let fixture: ComponentFixture<MeteoPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(MeteoPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/monitor-profile/monitor-profile.page.spec.ts
+++ b/src/app/pages/monitor-profile/monitor-profile.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MonitorProfilePage } from './monitor-profile.page';
 
 describe('MonitorProfilePage', () => {
   let component: MonitorProfilePage;
   let fixture: ComponentFixture<MonitorProfilePage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(MonitorProfilePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/notifications/notifications.page.spec.ts
+++ b/src/app/pages/notifications/notifications.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NotificationsPage } from './notifications.page';
 
 describe('NotificationsPage', () => {
   let component: NotificationsPage;
   let fixture: ComponentFixture<NotificationsPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(NotificationsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/register-complete/register-complete.page.spec.ts
+++ b/src/app/pages/register-complete/register-complete.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RegisterCompletePage } from './register-complete.page';
 
 describe('RegisterCompletePage', () => {
   let component: RegisterCompletePage;
   let fixture: ComponentFixture<RegisterCompletePage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(RegisterCompletePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/register-monitor/register-monitor.page.spec.ts
+++ b/src/app/pages/register-monitor/register-monitor.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RegisterMonitorPage } from './register-monitor.page';
 
 describe('RegisterMonitorPage', () => {
   let component: RegisterMonitorPage;
   let fixture: ComponentFixture<RegisterMonitorPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(RegisterMonitorPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/register/register.page.spec.ts
+++ b/src/app/pages/register/register.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RegisterPage } from './register.page';
 
 describe('RegisterPage', () => {
   let component: RegisterPage;
   let fixture: ComponentFixture<RegisterPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(RegisterPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/scan-client/scan-client.page.spec.ts
+++ b/src/app/pages/scan-client/scan-client.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ScanClientPage } from './scan-client.page';
 
 describe('ScanClientPage', () => {
   let component: ScanClientPage;
   let fixture: ComponentFixture<ScanClientPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(ScanClientPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/scan/scan.page.spec.ts
+++ b/src/app/pages/scan/scan.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ScanPage } from './scan.page';
 
 describe('ScanPage', () => {
   let component: ScanPage;
   let fixture: ComponentFixture<ScanPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(ScanPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/school-add/school-add.page.spec.ts
+++ b/src/app/pages/school-add/school-add.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { SchoolAddPage } from './school-add.page';
 
 describe('SchoolAddPage', () => {
   let component: SchoolAddPage;
   let fixture: ComponentFixture<SchoolAddPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(SchoolAddPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/schools/schools.page.spec.ts
+++ b/src/app/pages/schools/schools.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { SchoolsPage } from './schools.page';
 
 describe('SchoolsPage', () => {
   let component: SchoolsPage;
   let fixture: ComponentFixture<SchoolsPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(SchoolsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/start/start.page.spec.ts
+++ b/src/app/pages/start/start.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { StartPage } from './start.page';
 
 describe('StartPage', () => {
   let component: StartPage;
   let fixture: ComponentFixture<StartPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(StartPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/pages/stats/stats.page.spec.ts
+++ b/src/app/pages/stats/stats.page.spec.ts
@@ -1,11 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { StatsPage } from './stats.page';
 
 describe('StatsPage', () => {
   let component: StatsPage;
   let fixture: ComponentFixture<StatsPage>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(StatsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();


### PR DESCRIPTION
## Summary
- replace deprecated async with waitForAsync in page-level spec files

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: ChromeHeadless cannot start, requires snap chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68beb6002d1483209e2d4a78b20d3298